### PR TITLE
[Cursor] Add conversation root directory feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ ENV/
 screenshots/
 logs/
 *.log
-claude-tooling/temp/
+claude-tooling/runs/
 
 # JavaScript/Frontend
 node_modules/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Cursor-like AI development environment with advanced agentic capabilities, on 
 - **File Management** tools for reading and writing files
 - **Command Execution** capabilities for terminal operations
 - **Web Tools** for searching and extracting web content
+- **Conversation Root Directories** - Each conversation is automatically assigned a unique directory in `runs/<timestamp>` for better organization of generated files
 
 ## Testing
 


### PR DESCRIPTION
This PR adds support for conversation-specific file storage directories.

Key changes:
- Each conversation is assigned a unique directory in runs/<timestamp>
- File operations now use this directory as root by default
- Added documentation in README.md
- Updated .gitignore to exclude runs/ directory