### PR TITLE
[Cursor] Add automatic tool execution limit

### DIFF
--- a/claude-tooling/app/api/app.py
+++ b/claude-tooling/app/api/app.py
@@ -48,9 +48,13 @@ try:
     )
     logger.info("Anthropic client initialized successfully")
 
-    # Inject the client into the chat router
+    # Inject the client into the chat and conversation routers
     from .routes.chat import set_anthropic_client
     set_anthropic_client(client)
+    
+    # Set client for conversation router for resume endpoint
+    from .routes.conversation import set_anthropic_client as set_conversation_anthropic_client
+    set_conversation_anthropic_client(client)
 
 except Exception as e:
     logger.error(f"Failed to initialize Anthropic client: {str(e)}")

--- a/claude-tooling/app/api/routes/chat.py
+++ b/claude-tooling/app/api/routes/chat.py
@@ -13,7 +13,8 @@ from ..models.schemas import Message, UserRequest, UserResponse, ToolOutput
 from ..services.conversation import (
     conversations, conversation_root_dirs, 
     create_conversation_root_dir, add_message_to_conversation,
-    get_conversation, get_root_dir, get_task_status, set_task_status
+    get_conversation, get_root_dir, get_task_status, set_task_status,
+    reset_auto_execute_count
 )
 from ..services.tool_execution import process_tool_calls_and_continue, auto_execute_tool_calls
 from ..tools.tool_wrapper import TOOL_DEFINITIONS, format_tool_results_for_claude

--- a/claude-tooling/app/api/routes/conversation.py
+++ b/claude-tooling/app/api/routes/conversation.py
@@ -4,12 +4,14 @@ Conversation management routes.
 
 import logging
 from typing import Dict, Any
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, BackgroundTasks
 
 from ..services.conversation import (
-    conversations, get_conversation, get_root_dir
+    conversations, get_conversation, get_root_dir,
+    set_task_status, get_task_status, reset_auto_execute_count
 )
 from ..services.file_service import list_files, get_file_path, get_file_content_type
+from ..services.tool_execution import process_tool_calls_and_continue
 
 # Configure logging
 logging.basicConfig(
@@ -20,6 +22,15 @@ logger = logging.getLogger(__name__)
 
 # Create router
 router = APIRouter(prefix="/api/conversation")
+
+# Anthropic client - will be set from app.py
+client = None
+
+def set_anthropic_client(anthropic_client):
+    """Set the Anthropic client for this module"""
+    global client
+    client = anthropic_client
+    logger.info("Anthropic client set in conversation router")
 
 @router.get("/{conversation_id}/messages")
 async def get_conversation_messages(conversation_id: str):
@@ -37,21 +48,28 @@ async def get_conversation_messages(conversation_id: str):
         # Get conversation history
         history = get_conversation(conversation_id)
         
-        # Check conversation status
-        # Find the last message, if it's assistant message and no tool calls, then consider conversation completed
-        status = "in_progress"
-        if history and len(history) > 0:
-            last_message = history[-1]
-            if last_message["role"] == "assistant":
-                # Check if there are tool calls
-                has_tool_call = False
-                for item in last_message["content"]:
-                    if isinstance(item, dict) and item.get("type") == "tool_use":
-                        has_tool_call = True
-                        break
-                
-                if not has_tool_call:
-                    status = "completed"
+        # Check conversation status from auto_execute_tasks first
+        task_status = get_task_status(conversation_id)
+        
+        if task_status == "paused":
+            # Tool execution is paused (hit the limit)
+            status = "paused"
+        else:
+            # Check messages to determine status
+            # Find the last message, if it's assistant message and no tool calls, then consider conversation completed
+            status = "in_progress"
+            if history and len(history) > 0:
+                last_message = history[-1]
+                if last_message["role"] == "assistant":
+                    # Check if there are tool calls
+                    has_tool_call = False
+                    for item in last_message["content"]:
+                        if isinstance(item, dict) and item.get("type") == "tool_use":
+                            has_tool_call = True
+                            break
+                    
+                    if not has_tool_call:
+                        status = "completed"
         
         # Get the conversation root directory if available
         root_dir = get_root_dir(conversation_id)
@@ -113,4 +131,108 @@ async def list_conversation_files(conversation_id: str):
         logger.error(f"[FILE LISTING] Error listing files: {str(e)}")
         import traceback
         logger.error(f"[FILE LISTING] Traceback: {traceback.format_exc()}")
-        raise HTTPException(status_code=500, detail=f"Error listing files: {str(e)}") 
+        raise HTTPException(status_code=500, detail=f"Error listing files: {str(e)}")
+        
+@router.post("/{conversation_id}/resume")
+async def resume_auto_execution(
+    conversation_id: str,
+    background_tasks: BackgroundTasks,
+    max_tokens: int = 4096,
+    thinking_mode: bool = True,
+    thinking_budget_tokens: int = 2000
+):
+    """
+    Resume automatic tool execution after reaching the limit.
+    """
+    try:
+        logger.info(f"Received resume automatic execution request, conversation ID: {conversation_id}")
+        
+        if conversation_id not in conversations:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        
+        # Get the current status
+        status = get_task_status(conversation_id)
+        if status != "paused":
+            raise HTTPException(status_code=400, detail=f"Cannot resume execution, status is {status}")
+        
+        # Reset the counter and set status back to running
+        reset_auto_execute_count(conversation_id)
+        set_task_status(conversation_id, "running")
+        
+        # Add system message to conversation history
+        add_message_to_conversation(
+            conversation_id,
+            {
+                "role": "system", 
+                "content": [{"type": "text", "text": "Automatic tool execution resumed by user"}]
+            }
+        )
+        
+        # Get the tool calls from the last assistant message
+        history = get_conversation(conversation_id)
+        recent_messages = [m for m in history if m["role"] == "assistant"]
+        
+        if not recent_messages:
+            raise HTTPException(status_code=400, detail="No assistant messages found")
+        
+        last_assistant_message = recent_messages[-1]
+        content = last_assistant_message.get("content", [])
+        
+        tool_calls = []
+        for item in content:
+            if isinstance(item, dict) and item.get('type') == 'tool_use':
+                tool_calls.append({
+                    "id": item.get('id'),
+                    "name": item.get('name'),
+                    "input": item.get('input', {})
+                })
+        
+        if not tool_calls:
+            raise HTTPException(status_code=400, detail="No tool calls found in last assistant message")
+        
+        # Start a background task to continue processing the tool calls
+        background_tasks.add_task(
+            process_tool_calls_and_continue, 
+            tool_calls, 
+            conversation_id, 
+            max_tokens, 
+            thinking_mode, 
+            thinking_budget_tokens,
+            True,  # auto_execute_tools
+            client
+        )
+        
+        return {"status": "success", "message": "Automatic tool execution resumed"}
+        
+    except Exception as e:
+        logger.error(f"Error resuming automatic execution: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+        
+@router.post("/{conversation_id}/cancel")
+async def cancel_auto_execution(conversation_id: str):
+    """
+    Cancel ongoing automatic tool execution.
+    Allows user to interrupt long-running automatic tool execution process.
+    """
+    try:
+        logger.info(f"Received cancel automatic execution request, conversation ID: {conversation_id}")
+        
+        if conversation_id not in conversations:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        
+        set_task_status(conversation_id, "cancelled")
+        
+        # Add system message to conversation history
+        add_message_to_conversation(
+            conversation_id,
+            {
+                "role": "system", 
+                "content": [{"type": "text", "text": "Automatic tool execution cancelled by user"}]
+            }
+        )
+        
+        return {"status": "success", "message": "Automatic tool execution cancelled"}
+        
+    except Exception as e:
+        logger.error(f"Error cancelling automatic execution: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e)) 

--- a/claude-tooling/app/api/routes/conversation.py
+++ b/claude-tooling/app/api/routes/conversation.py
@@ -8,7 +8,8 @@ from fastapi import APIRouter, HTTPException, BackgroundTasks
 
 from ..services.conversation import (
     conversations, get_conversation, get_root_dir,
-    set_task_status, get_task_status, reset_auto_execute_count
+    set_task_status, get_task_status, reset_auto_execute_count,
+    add_message_to_conversation
 )
 from ..services.file_service import list_files, get_file_path, get_file_content_type
 from ..services.tool_execution import process_tool_calls_and_continue
@@ -160,7 +161,8 @@ async def resume_auto_execution(
         set_task_status(conversation_id, "running")
         
         # Add system message to conversation history
-        add_message_to_conversation(
+        from ..services.conversation import add_message_to_conversation as add_msg
+        add_msg(
             conversation_id,
             {
                 "role": "system", 

--- a/claude-tooling/app/api/services/conversation.py
+++ b/claude-tooling/app/api/services/conversation.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 conversations = {}
 conversation_root_dirs = {}
 auto_execute_tasks = {}
+auto_execute_counts = {}  # Track the number of automatic tool executions per conversation
 
 def create_conversation_root_dir(conversation_id: str) -> str:
     """
@@ -105,4 +106,41 @@ def set_task_status(conversation_id: str, status: str) -> None:
         conversation_id: The conversation ID
         status: The task status
     """
-    auto_execute_tasks[conversation_id] = status 
+    auto_execute_tasks[conversation_id] = status
+    
+def get_auto_execute_count(conversation_id: str) -> int:
+    """
+    Get the count of automatic tool executions for a conversation.
+    
+    Args:
+        conversation_id: The conversation ID
+        
+    Returns:
+        The count or 0 if not found
+    """
+    return auto_execute_counts.get(conversation_id, 0)
+
+def increment_auto_execute_count(conversation_id: str) -> int:
+    """
+    Increment the count of automatic tool executions for a conversation.
+    
+    Args:
+        conversation_id: The conversation ID
+        
+    Returns:
+        The new count
+    """
+    if conversation_id not in auto_execute_counts:
+        auto_execute_counts[conversation_id] = 0
+    
+    auto_execute_counts[conversation_id] += 1
+    return auto_execute_counts[conversation_id]
+
+def reset_auto_execute_count(conversation_id: str) -> None:
+    """
+    Reset the count of automatic tool executions for a conversation.
+    
+    Args:
+        conversation_id: The conversation ID
+    """
+    auto_execute_counts[conversation_id] = 0 

--- a/claude-tooling/tests/test_auto_execute.py
+++ b/claude-tooling/tests/test_auto_execute.py
@@ -393,8 +393,8 @@ async def test_resume_after_limit(mock_anthropic_client):
     with patch.object(background_tasks, 'add_task') as mock_add_task:
         # Call resume function
         from fastapi import HTTPException
-        # Mock the add_message_to_conversation function to prevent errors
-        with patch('app.api.routes.conversation.add_message_to_conversation') as mock_add_message:
+        # Mock the add_message_to_conversation function in the correct module
+        with patch('app.api.services.conversation.add_message_to_conversation') as mock_add_message:
             with patch('app.api.routes.conversation.process_tool_calls_and_continue') as mock_process:
                 # Mock the client in conversation router
                 from app.api.routes.conversation import client


### PR DESCRIPTION
## Summary
- Added limit of 10 auto-executed tools before pausing execution
- Added tracking of auto-execution count per conversation 
- Implemented pause/resume functionality for tool executions
- Added conversation status to show when execution is paused
- Added resume endpoint to continue execution when requested
- Updated app.py to inject Anthropic client into conversation router

## Test plan
- Test auto-execution by running long chains of tools (>10)
- Verify the execution pauses after 10 tools with a message
- Test resuming execution via the resume endpoint
- Check conversation status shows "paused" when limit is reached

🤖 Generated with Claude Code