### PR TITLE
[Cursor] Fix 'os not defined' error on Windows

### DIFF
--- a/claude-tooling/app/api/tools/web_tools.py
+++ b/claude-tooling/app/api/tools/web_tools.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import time
+import os
 from typing import Dict, Any, List, Optional
 import httpx
 from urllib.parse import urlparse


### PR DESCRIPTION
Added explicit import of the os module in web_tools.py to ensure cross-platform compatibility. On Windows, os was being used but not imported, causing runtime errors.\n\nFix issue #30